### PR TITLE
Fix round team persistence bug and align test config/spec

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.scss",
+              "src/black-red.css"
             ],
             "scripts": []
           }

--- a/src/app/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ConfirmDialogComponentComponent } from './confirm-dialog.component';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
 
 describe('ConfirmDialogComponent', () => {
   let component: ConfirmDialogComponent;
@@ -8,7 +8,7 @@ describe('ConfirmDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ConfirmDialogComponentComponent ]
+      declarations: [ ConfirmDialogComponent ]
     })
     .compileComponents();
 

--- a/src/app/services/round-mediator/round-mediator.service.ts
+++ b/src/app/services/round-mediator/round-mediator.service.ts
@@ -310,7 +310,7 @@ export class RoundMediatorService {
 
                         // create teams
                         tableData.teams.forEach((team) => {
-                          this.teamService.addTeam(team, newTable.id, round.id, gameId);
+                          this.teamService.addTeam(team, addedTable.id, round.id, gameId);
                         });
 
                         return of(addedTable);


### PR DESCRIPTION
### Motivation
- Prevent teams from being associated with an unpersisted table object which could store an undefined or incorrect table reference. 
- Allow Karma test runs to compile by referencing existing style files instead of a missing `src/styles.css`. 
- Fix failing unit test compilation caused by an incorrect component import/name in the confirm dialog spec. 

### Description
- In `RoundMediatorService.createRound` change team creation to use the persisted table id returned from `addTable` by replacing `newTable.id` with `addedTable.id`. 
- Update `angular.json` test `styles` to include `src/styles.scss` and `src/black-red.css` instead of `src/styles.css`. 
- Fix `src/app/components/confirm-dialog/confirm-dialog.component.spec.ts` to import and declare `ConfirmDialogComponent` instead of `ConfirmDialogComponentComponent`. 

### Testing
- `npm run build` completed successfully and produced the application bundles. 
- `npm test -- --watch=false --browsers=ChromeHeadless` now compiles the test bundles; test runtime did not execute in this environment because the `ChromeHeadless` binary is not available (`CHROME_BIN` not set). 
- TypeScript/Karma compilation errors related to the confirm-dialog spec and missing styles were resolved (compilation now proceeds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8151c8b883209d935be98e56a229)